### PR TITLE
Fix PVR OSD buttons click area

### DIFF
--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -225,7 +225,7 @@
     <include name="OSD_LiveTVPosition">
         <align>center</align>
         <height>48</height>
-        <centerbottom>121</centerbottom>
+        <centerbottom>95</centerbottom>
         <left>331</left>
         <width>723</width>
         <itemgap>36</itemgap>
@@ -252,7 +252,7 @@
                 <left>0</left>
                 <width>227</width>
                 <height>227</height>
-                <bottom>0</bottom>
+                <bottom>-26</bottom>
                 <control type="image">
                     <texture colordiffuse="panel_bg" border="10">diffuse/box.png</texture>
                     <animation effect="fade" end="75" condition="true">Conditional</animation>
@@ -283,7 +283,7 @@
                 <left>231</left>
                 <width>762.5</width>
                 <height>227</height>
-                <bottom>0</bottom>
+                <bottom>-26</bottom>
                 <control type="image">
                     <texture colordiffuse="panel_bg" border="10">diffuse/box.png</texture>
                     <animation effect="fade" end="75" condition="true">Conditional</animation>
@@ -381,7 +381,7 @@
                 <left>997.5</left>
                 <width>762.5</width>
                 <height>227</height>
-                <bottom>0</bottom>
+                <bottom>-26</bottom>
                 <control type="image">
                     <texture colordiffuse="panel_bg" border="10">diffuse/box.png</texture>
                     <animation effect="fade" end="75" condition="true">Conditional</animation>


### PR DESCRIPTION
In PVR menu clicking the OSD buttons registered only below the buttons (stop, rewind etc.). Clicking them in the current position just resets playback. This fixes it.